### PR TITLE
Dynamic URL Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Here is what your .tongs_config file should look like. You can add as many confi
 as you need, as long as the default and settings. Not all fields are required for all sections
 but you can currently use project-key, duration, reviewers and title as you see fit. There is no restriction on spacing 
 around the commas and equal signs. Also titles should be written without quotes of any kind. 
-Note: you must have at least a default project-key to create reviews.
+Note: you must have at least a default project-key to create reviews. If this project key is invalid for the Crucible instance you are using, the review will not be created. Also, for the baseurl, add any nessesary url paths to the base url such as /viewer if needed, just omit the trailing slash.
 
     [default]
     project-key=PROJECT-KEY

--- a/crucible/crucible.go
+++ b/crucible/crucible.go
@@ -51,7 +51,7 @@ func CreateReview(reviewName string, templateName string, reviewLength int64, us
 	if id, ok := createReviewPost(json, token, baseUrl); ok {
 		
 		fmt.Println("Review Created:",id)
-		fmt.Println("("+baseUrl+"/viewer/cru/"+id+")")
+		fmt.Println("("+baseUrl+"/cru/"+id+")")
 		fmt.Println("Using Tongs Template:", templateName)
 		fmt.Println("Due Date Calculated:", dueDate)
 		fmt.Println("Review Title:", reviewName)
@@ -69,7 +69,7 @@ func CreateReview(reviewName string, templateName string, reviewLength int64, us
 	return false, ""
 }
 func addReviewersPost(token string, baseUrl string, permaId string, userName string) {
-	restUrl := baseUrl + "/viewer/rest-service/reviews-v1/" + permaId + "/reviewers?FEAUTH=" + token
+	restUrl := baseUrl + "/rest-service/reviews-v1/" + permaId + "/reviewers?FEAUTH=" + token
 	client := &http.Client{}
 	req, _ := http.NewRequest("POST", restUrl, bytes.NewBuffer([]byte(userName)))
 	client.Do(req)
@@ -154,7 +154,7 @@ func calculateDueDate(days int64) string {
 }
 
 func Login(userName string, password string, baseUrl string) string {
-	restUrl := baseUrl + "/viewer/rest-service/auth-v1/login"
+	restUrl := baseUrl + "/rest-service/auth-v1/login"
 
 	resp, err := http.PostForm(restUrl, url.Values{"userName": {strings.ToLower(userName)}, "password": {password}})
 	if err != nil {


### PR DESCRIPTION
Removed prefixed /viewer from rest api calls so that crucible instances that did not have that in the url could use tongs. Now for users with /viewer in the url this will need to be added to the tongs config baseurl.
